### PR TITLE
Update peerDependencies to support redux@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "redux-storage-merger-simple": "^1.0.2"
   },
   "peerDependencies": {
-    "redux": "^3.0.0 || ^2.0.0 || ^1.0.0 || 1.0.0-alpha || 1.0.0-rc"
+    "redux": "^4.0.0 || ^3.0.0 || ^2.0.0 || ^1.0.0 || 1.0.0-alpha || 1.0.0-rc"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
There are no breaking changes relative to this plugin. The middleware api hasn't changed.