### PR TITLE
Make dispatching redux action on save opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ import { SHOULD_SAVE } from './constants';
 const middleware = createMiddleware(engine, [], [ SHOULD_SAVE ]);
 ```
 
+If you want to skip dispatching a redux action everytime something gets saved,
+just specify it to the option object, which is the fourth argument.
+
+```js
+import { createMiddleware } from 'redux-storage'
+
+import { SHOULD_SAVE } from './constants';
+
+const middleware = createMiddleware(engine, [], [], { disableDispatchSaveAction: true });
+```
+
 # A fork of [redux-storage](https://github.com/michaelcontento/redux-storage)
 
 The original author of the package [redux-storage](https://github.com/michaelcontento/redux-storage) has decided to deprecate the project and no longer maintained. The package will now be maintained here.

--- a/src/createMiddleware.js
+++ b/src/createMiddleware.js
@@ -62,7 +62,9 @@ function handleWhitelist(action, actionWhitelist) {
     return actionWhitelist(action);
 }
 
-export default (engine, actionBlacklist = [], actionWhitelist = []) => {
+export default (engine, actionBlacklist = [], actionWhitelist = [], options = {}) => {
+    const opts = Object.assign({ disableDispatchSaveAction: false }, options);
+
     // Also don't save if we process our own actions
     const blacklistedActions = [...actionBlacklist, LOAD, SAVE];
 
@@ -94,7 +96,13 @@ export default (engine, actionBlacklist = [], actionWhitelist = []) => {
                 }
 
                 const dispatchSave = () => dispatch(saveAction);
-                engine.save(saveState).then(dispatchSave).catch(swallow);
+                engine.save(saveState)
+                    .then(() => {
+                        if (opts.disableDispatchSaveAction === false) {
+                            return dispatchSave();
+                        }
+                    })
+                    .catch(swallow);
             }
 
             return result;


### PR DESCRIPTION
This PR will add a options object as a fourth argument to `createMiddleware` that now let the develop skip the dispatch on save if they don't have the need for it. 

I'm working on a project where basically our redux logger gets polluted by these actions and some containers causes `componentDidUpdate` trigger twice because of these extra actions dispatch we're not using.

Let me know if you need anything from me!