### PR TITLE
build: add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "build/index.js",
   "jsnext:main": "build-es/index.js",
   "scripts": {
+    "prepare": "make build",
     "test": "make lint test build"
   },
   "repository": {


### PR DESCRIPTION
I needed to use this fork, but the prepare script was missing; it build the library, before installing it